### PR TITLE
Add autocomplete support for responding an slash command

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -534,6 +534,7 @@ class InteractionType(Enum):
     ping = 1
     application_command = 2
     component = 3
+    autocomplete = 4
 
 
 class InteractionResponseType(Enum):
@@ -544,6 +545,7 @@ class InteractionResponseType(Enum):
     deferred_channel_message = 5  # (with source)
     deferred_message_update = 6  # for components
     message_update = 7  # for components
+    autocomplete_result = 8  # app command, string only
 
 
 class ApplicationCommandType(Enum):

--- a/discord/ext/app/errors.py
+++ b/discord/ext/app/errors.py
@@ -42,6 +42,8 @@ __all__ = (
     "ApplicationRegistrationError",
     "ApplicationRegistrationMaxDepthError",
     "ApplicationRegistrationExistingParentOptions",
+    "ApplicationAutocompleteError",
+    "ApplicationNoAutocomplete",
     "ApplicationUserInputError",
     "ApplicationMissingRequiredArgument",
     "ApplicationTooManyArguments",
@@ -162,6 +164,36 @@ class ApplicationRegistrationExistingParentOptions(ClientException):
         super().__init__(
             f"The command '{name}' cannot be registered since the parent command contains option '{option.name}'"
             f" which is a type '{option.input_type.name}' (need to be subcommand or group)"
+        )
+
+
+class ApplicationAutocompleteError(ApplicationCommandError):
+    """The base exception type for errors that involve autocomplete.
+
+    This inherits from :exc:`ApplicationCommandError`.
+    """
+
+    pass
+
+
+class ApplicationNoAutocomplete(ApplicationAutocompleteError):
+    """An exception that will be raised if you try to respond with
+    autocomplete where there is nothing to be autocompleted.
+
+    This errors will be raised from client side and not server side.
+
+    This inherits from :exc:`ApplicationAutocompleteError`.
+
+    Attributes
+    -----------
+    name: :class:`str`
+        The command name that had the error.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name: str = name
+        super().__init__(
+            f"The command '{name}' has no need to do anymore autocompletion respond currently."
         )
 
 

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from .channel import ChannelType
 from .components import Component, ComponentType
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from .message import AllowedMentions, Message
 
 
-ApplicationCommandType = Literal[1, 2, 3]
+ApplicationCommandType = Literal[1, 2, 3, 4]
 
 
 class _ApplicationCommandOptional(TypedDict, total=False):
@@ -132,6 +132,12 @@ class _ApplicationCommandInteractionDataOptionNumber(_ApplicationCommandInteract
     value: float
 
 
+class _ApplicationCommandInteractionDataAutocomplete(_ApplicationCommandInteractionDataOption):
+    type: ApplicationCommandOptionType
+    value: Any
+    focused: bool
+
+
 ApplicationCommandInteractionDataOption = Union[
     _ApplicationCommandInteractionDataOptionString,
     _ApplicationCommandInteractionDataOptionInteger,
@@ -139,6 +145,7 @@ ApplicationCommandInteractionDataOption = Union[
     _ApplicationCommandInteractionDataOptionBoolean,
     _ApplicationCommandInteractionDataOptionSnowflake,
     _ApplicationCommandInteractionDataOptionNumber,
+    _ApplicationCommandInteractionDataAutocomplete,
 ]
 
 
@@ -206,7 +213,7 @@ class InteractionApplicationCommandCallbackData(TypedDict, total=False):
     components: List[Component]
 
 
-InteractionResponseType = Literal[1, 4, 5, 6, 7]
+InteractionResponseType = Literal[1, 4, 5, 6, 7, 8]
 
 
 class _InteractionResponseOptional(TypedDict, total=False):


### PR DESCRIPTION
Can be changing, will be merged whenever it goes live to almost everyone.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds support for responding to an autocomplete request.
Documentation will be written later.

Current sample:
```py
@app.slash_command()
@app.option("word", str, autocomplete=True)
async def guess(ctx, word: str):
	# .autocompleting should return the focused parameter name
	# so if user is autocompleting "word", it should be "word"
	# It can be none if nothing is being focused.
	if ctx.autocompleting == "word":
		await ctx.autocomplete(["a", "b", "c"])
		# OR
		await ctx.autocomplete([
			OptionChoice("A", "a"),
			OptionChoice("B", "b"),
		])
		return

	await ctx.send(f"Word is: {word}")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
